### PR TITLE
[FEAT] Add TwelveLabs Marengo encoder and Pegasus video parser

### DIFF
--- a/docs/source/reference/document_parser.rst
+++ b/docs/source/reference/document_parser.rst
@@ -23,3 +23,12 @@ This module provides a set of classes and functions for parsing a formated docum
     :members:
     :show-inheritance:
     :exclude-members: parse
+
+.. autoclass:: flexrag.document_parser.TwelveLabsVideoParserConfig
+    :members:
+    :inherited-members:
+
+.. autoclass:: flexrag.document_parser.TwelveLabsVideoParser
+    :members:
+    :show-inheritance:
+    :exclude-members: parse

--- a/docs/source/reference/encoders.rst
+++ b/docs/source/reference/encoders.rst
@@ -82,6 +82,17 @@ Oneline Encoders
     :exclude-members: async_encode, encode
 
 
+.. TwelveLabs Encoders
+.. autoclass:: flexrag.models.TwelveLabsEncoderConfig
+    :members:
+    :inherited-members:
+
+.. autoclass:: flexrag.models.TwelveLabsEncoder
+    :members:
+    :show-inheritance:
+    :exclude-members: async_encode, encode
+
+
 .. OpenAI Encoders
 .. autoclass:: flexrag.models.OpenAIEncoderConfig
     :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "accelerate",
     "mixedbread",
     "voyageai",
+    "twelvelabs>=1.2.8",
     # databases
     "lmdb",
     "msgpack",

--- a/src/flexrag/document_parser/__init__.py
+++ b/src/flexrag/document_parser/__init__.py
@@ -1,6 +1,7 @@
 from .docling_parser import DoclingConfig, DoclingParser
 from .document_parser_base import DOCUMENTPARSERS, Document, DocumentParserBase
 from .markitdown_parser import MarkItDownParser
+from .twelvelabs_parser import TwelveLabsVideoParser, TwelveLabsVideoParserConfig
 
 DocumentParserConfig = DOCUMENTPARSERS.make_config(default="markitdown")
 
@@ -13,4 +14,6 @@ __all__ = [
     "DoclingParser",
     "DoclingConfig",
     "MarkItDownParser",
+    "TwelveLabsVideoParser",
+    "TwelveLabsVideoParserConfig",
 ]

--- a/src/flexrag/document_parser/twelvelabs_parser.py
+++ b/src/flexrag/document_parser/twelvelabs_parser.py
@@ -1,0 +1,88 @@
+import os
+from typing import Optional
+
+from flexrag.utils import configure
+
+from .document_parser_base import DOCUMENTPARSERS, Document, DocumentParserBase
+
+
+@configure
+class TwelveLabsVideoParserConfig:
+    """Configuration for TwelveLabsVideoParser.
+
+    TwelveLabs `Pegasus <https://docs.twelvelabs.io/>`_ is a video-understanding
+    model. This parser turns a video (a local file or a publicly reachable URL)
+    into a textual :class:`Document` by prompting Pegasus, so that videos can be
+    indexed and retrieved alongside ordinary documents in FlexRAG.
+
+    :param model: The Pegasus model to use. Default is "pegasus1.5".
+    :type model: str
+    :param prompt: The instruction passed to Pegasus to describe the video.
+        Defaults to a generic summarization prompt.
+    :type prompt: str
+    :param max_tokens: The maximum number of tokens Pegasus may generate.
+        Defaults to 2048.
+    :type max_tokens: int
+    :param api_key: The API key for the TwelveLabs API.
+        If not provided, it will use the environment variable `TWELVELABS_API_KEY`.
+        Defaults to None.
+    :type api_key: Optional[str]
+    """
+
+    model: str = "pegasus1.5"
+    prompt: str = (
+        "Describe this video in detail, including the main events, "
+        "people, objects, and any spoken or on-screen text."
+    )
+    max_tokens: int = 2048
+    api_key: Optional[str] = None
+
+
+@DOCUMENTPARSERS("twelvelabs_video", config_class=TwelveLabsVideoParserConfig)
+class TwelveLabsVideoParser(DocumentParserBase):
+    """Parse a video into a textual ``Document`` using TwelveLabs Pegasus."""
+
+    def __init__(self, config: TwelveLabsVideoParserConfig):
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError:
+            raise ImportError(
+                "TwelveLabs is not installed. Please install it via `pip install twelvelabs`."
+            )
+
+        api_key = config.api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "API key for TwelveLabs is not provided. "
+                "Please set it in the configuration or as an environment variable 'TWELVELABS_API_KEY'."
+            )
+        self.client = TwelveLabs(api_key=api_key)
+        self.model = config.model
+        self.prompt = config.prompt
+        self.max_tokens = config.max_tokens
+        return
+
+    def parse(self, input_file_path: str) -> Document:
+        # A publicly reachable URL is analysed server-side; a local file is
+        # uploaded as an asset first and analysed by its asset id.
+        if input_file_path.startswith(("http://", "https://")):
+            video = {"type": "url", "url": input_file_path}
+        else:
+            assert os.path.exists(
+                input_file_path
+            ), f"Video file not found: {input_file_path}"
+            with open(input_file_path, "rb") as f:
+                asset = self.client.assets.create(method="direct", file=f)
+            video = {"type": "asset_id", "asset_id": asset.id}
+
+        response = self.client.analyze(
+            model_name=self.model,
+            video=video,
+            prompt=self.prompt,
+            max_tokens=self.max_tokens,
+        )
+        return Document(
+            source_file_path=input_file_path,
+            text=response.data,
+            title=os.path.basename(input_file_path),
+        )

--- a/src/flexrag/models/__init__.py
+++ b/src/flexrag/models/__init__.py
@@ -37,6 +37,7 @@ from .sentence_transformers_model import (
     SentenceTransformerEncoder,
     SentenceTransformerEncoderConfig,
 )
+from .twelvelabs_model import TwelveLabsEncoder, TwelveLabsEncoderConfig
 from .vllm_model import VLLMGenerator, VLLMGeneratorConfig
 
 GeneratorConfig = GENERATORS.make_config(config_name="GeneratorConfig")
@@ -76,6 +77,8 @@ __all__ = [
     "CohereEncoderConfig",
     "SentenceTransformerEncoder",
     "SentenceTransformerEncoderConfig",
+    "TwelveLabsEncoder",
+    "TwelveLabsEncoderConfig",
     "GENERATORS",
     "ENCODERS",
 ]

--- a/src/flexrag/models/twelvelabs_model.py
+++ b/src/flexrag/models/twelvelabs_model.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+from typing import Annotated, Optional
+
+import numpy as np
+from numpy import ndarray
+
+from flexrag.utils import TIME_METER, Choices, configure
+
+from .model_base import ENCODERS, EncoderBase, EncoderBaseConfig
+
+# The embedding dimension produced by the Marengo family of models.
+MARENGO_EMBEDDING_SIZE = 512
+
+
+@configure
+class TwelveLabsEncoderConfig(EncoderBaseConfig):
+    """Configuration for TwelveLabsEncoder.
+
+    TwelveLabs `Marengo <https://docs.twelvelabs.io/>`_ is a multimodal embedding
+    model that maps text, image, audio, and video into a single 512-dimensional
+    space. This encoder exposes the *text* embedding endpoint so that Marengo can
+    be used as a FlexRAG query/passage encoder that is directly comparable with
+    video embeddings produced by the same model.
+
+    :param model: The Marengo model to use. Default is "marengo3.0".
+    :type model: str
+    :param api_key: The API key for the TwelveLabs API.
+        If not provided, it will use the environment variable `TWELVELABS_API_KEY`.
+        Defaults to None.
+    :type api_key: Optional[str]
+    """
+
+    model: Annotated[str, Choices("marengo3.0")] = "marengo3.0"
+    api_key: Optional[str] = None
+
+
+@ENCODERS("twelvelabs", config_class=TwelveLabsEncoderConfig)
+class TwelveLabsEncoder(EncoderBase):
+    """Encode texts into the TwelveLabs Marengo 512-dimensional multimodal space."""
+
+    def __init__(self, cfg: TwelveLabsEncoderConfig):
+        super().__init__(cfg)
+        try:
+            from twelvelabs import AsyncTwelveLabs, TwelveLabs
+        except ImportError:
+            raise ImportError(
+                "TwelveLabs is not installed. Please install it via `pip install twelvelabs`."
+            )
+
+        api_key = cfg.api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "API key for TwelveLabs is not provided. "
+                "Please set it in the configuration or as an environment variable 'TWELVELABS_API_KEY'."
+            )
+        self.client = TwelveLabs(api_key=api_key)
+        self.async_client = AsyncTwelveLabs(api_key=api_key)
+        self.model = cfg.model
+        return
+
+    def _embed_one(self, text: str) -> list[float]:
+        r = self.client.embed.create(model_name=self.model, text=text)
+        return r.text_embedding.segments[0].float_
+
+    @TIME_METER("twelvelabs_encode")
+    def _encode(self, texts: list[str]) -> ndarray:
+        # The Marengo embed endpoint accepts a single text per request.
+        embeddings = [self._embed_one(text) for text in texts]
+        return np.array(embeddings)
+
+    @TIME_METER("twelvelabs_encode")
+    async def async_encode(self, texts: list[str]) -> ndarray:
+        async def embed_one(text: str) -> list[float]:
+            r = await self.async_client.embed.create(model_name=self.model, text=text)
+            return r.text_embedding.segments[0].float_
+
+        embeddings = await asyncio.gather(*[embed_one(text) for text in texts])
+        return np.array(embeddings)
+
+    @property
+    def embedding_size(self) -> int:
+        return MARENGO_EMBEDDING_SIZE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,6 +359,47 @@ def mock_anthropic_client(mocker):
 
 
 @pytest.fixture
+def mock_twelvelabs_client(mocker):
+    """Mock TwelveLabs client for testing TwelveLabsEncoder and parser."""
+
+    def make_embedding_response(text: str):
+        # Deterministic 512-dim Marengo-style embedding based on the text.
+        rng = np.random.default_rng(hash(text) % 2**32)
+        segment = mocker.MagicMock()
+        segment.float_ = rng.random(512).tolist()
+        response = mocker.MagicMock()
+        response.text_embedding.segments = [segment]
+        return response
+
+    def mock_embed_create(model_name, text, **kwargs):
+        return make_embedding_response(text)
+
+    async def mock_async_embed_create(model_name, text, **kwargs):
+        return make_embedding_response(text)
+
+    def mock_analyze(model_name, video, prompt, **kwargs):
+        response = mocker.MagicMock()
+        response.data = f"Mocked Pegasus analysis for model {model_name}."
+        return response
+
+    # Sync client (used by the encoder and the video parser)
+    mock_client = mocker.MagicMock()
+    mock_client.embed.create = mock_embed_create
+    mock_client.analyze = mock_analyze
+
+    # Async client (used by TwelveLabsEncoder.async_encode)
+    mock_async_client = mocker.MagicMock()
+    mock_async_client.embed.create = mock_async_embed_create
+
+    mock_twelvelabs_module = mocker.MagicMock()
+    mock_twelvelabs_module.TwelveLabs.return_value = mock_client
+    mock_twelvelabs_module.AsyncTwelveLabs.return_value = mock_async_client
+
+    mocker.patch.dict("sys.modules", {"twelvelabs": mock_twelvelabs_module})
+    return {"sync": mock_client, "async": mock_async_client}
+
+
+@pytest.fixture
 def mock_es_client(mocker):
     client_state = {
         "indexes": {},

--- a/tests/test_document_parser.py
+++ b/tests/test_document_parser.py
@@ -1,0 +1,21 @@
+import pytest
+
+from flexrag.document_parser import (
+    Document,
+    TwelveLabsVideoParser,
+    TwelveLabsVideoParserConfig,
+)
+
+
+class TestTwelveLabsVideoParser:
+    def test_parse_url(self, mock_twelvelabs_client):
+        parser = TwelveLabsVideoParser(
+            TwelveLabsVideoParserConfig(model="pegasus1.5", api_key="test")
+        )
+        url = "https://example.com/sample.mp4"
+        document = parser.parse(url)
+        assert isinstance(document, Document)
+        assert document.source_file_path == url
+        assert isinstance(document.text, str)
+        assert "Pegasus" in document.text
+        return

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -29,6 +29,8 @@ from flexrag.models import (
     OpenAIGeneratorConfig,
     SentenceTransformerEncoder,
     SentenceTransformerEncoderConfig,
+    TwelveLabsEncoder,
+    TwelveLabsEncoderConfig,
     VLLMGenerator,
     VLLMGeneratorConfig,
 )
@@ -255,5 +257,14 @@ class TestEncode:
     @pytest.mark.asyncio
     async def test_cohere(self, mock_cohere_client):
         encoder = CohereEncoder(CohereEncoderConfig(model="embed-v4.0", api_key="test"))
+        await self.run_encoder(encoder)
+        return
+
+    @pytest.mark.asyncio
+    async def test_twelvelabs(self, mock_twelvelabs_client):
+        encoder = TwelveLabsEncoder(
+            TwelveLabsEncoderConfig(model="marengo3.0", api_key="test")
+        )
+        assert encoder.embedding_size == 512
         await self.run_encoder(encoder)
         return


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an opt-in [TwelveLabs](https://twelvelabs.io) integration with two pieces, wired through FlexRAG's existing registries:

**1. `TwelveLabsEncoder` (Marengo) — `flexrag.models`, registered as `twelvelabs`**
Encodes text into TwelveLabs' Marengo 512-dimensional multimodal embedding space (`marengo3.0`). Because Marengo embeds text, image, audio, and video into one shared space, FlexRAG queries/passages encoded this way are directly comparable with video embeddings produced by the same model — useful for video-centric RAG. Mirrors the existing `CohereEncoder`/`JinaEncoder`: subclasses `EncoderBase`, lazy-imports the SDK, reads the key from config or `TWELVELABS_API_KEY`, and implements both `_encode` and `async_encode`.

**2. `TwelveLabsVideoParser` (Pegasus) — `flexrag.document_parser`, registered as `twelvelabs_video`**
Turns a video (local file or public URL) into a textual `Document` by prompting TwelveLabs' Pegasus video-understanding model, so videos can be indexed and retrieved alongside ordinary documents. Follows the `DocumentParserBase.parse(path) -> Document` contract used by `DoclingParser`/`MarkItDownParser`.

**Opt-in / non-breaking:** both are new registry entries under new keys; no defaults change and no existing behavior is touched. The SDK is lazy-imported, so the modules don't import unless the provider is selected.

**Testing**
- Real API smoke test: `TwelveLabsEncoder.encode` / `async_encode` return `(N, 512)` vectors from the live Marengo endpoint.
- Pegasus parser wiring verified (request args + `Document` shape); video-context dicts validated against the SDK's pydantic types. Full Pegasus run is server-side and slow, so wiring is verified and a full run is pending.
- Added a no-network unit test for each (`tests/test_model.py::TestEncode::test_twelvelabs`, `tests/test_document_parser.py`) gated on a mocked SDK client in `conftest.py`, matching the repo's mock-based encoder tests.
- Added docs (`encoders.rst`, `document_parser.rst`), the `twelvelabs>=1.2.8` dependency, and registry/`__init__` wiring. `black` clean.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
